### PR TITLE
Add database schema and tests

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -135,3 +135,12 @@ Revisar `docs/brand.md`.
 2. **Hogar primerizo:** “Compré mi primera casa y quiero reforzar el techo poco a poco.”
 3. **MFI en expansión:** “Somos una microfinanciera y buscamos nuevos leads para ofrecer microcréditos a propietarios.”
 4. **Constructora local:** “Dirijo una constructora pequeña y quiero más proyectos modulares.”
+
+## 8. Persistencia de datos
+
+Los formularios guardan la información en tablas separadas usando Drizzle ORM:
+
+1. **households**: datos del perfil Hogar.
+2. **microfinance_institutions**: información de MFIs.
+3. **construction_companies**: registros de constructoras.
+

--- a/src/db/schema/construction-companies.ts
+++ b/src/db/schema/construction-companies.ts
@@ -1,0 +1,17 @@
+import { timestamp, varchar, text, serial } from "drizzle-orm/pg-core";
+import { schema } from "./schema";
+
+/** ConstructionCompanies stores constructor leads. */
+export const constructionCompanies = schema.table("construction_companies", {
+	id: serial("id").primaryKey(),
+	companyName: varchar("company_name", { length: 255 }).notNull(),
+	contactName: varchar("contact_name", { length: 255 }).notNull(),
+	workAreas: varchar("work_areas", { length: 255 }),
+	executionCapacity: varchar("execution_capacity", { length: 255 }),
+	email: varchar("email", { length: 255 }).notNull(),
+	phone: varchar("phone", { length: 25 }).notNull(),
+	notes: text("notes"),
+	createdAt: timestamp("created_at", { withTimezone: true })
+		.defaultNow()
+		.notNull(),
+});

--- a/src/db/schema/households.ts
+++ b/src/db/schema/households.ts
@@ -1,0 +1,29 @@
+import {
+	timestamp,
+	varchar,
+	text,
+	integer,
+	pgTable,
+	serial,
+} from "drizzle-orm/pg-core";
+import { schema } from "./schema";
+
+/** Households captures home-owner leads. */
+export const households = schema.table("households", {
+	id: serial("id").primaryKey(),
+	fullName: varchar("full_name", { length: 255 }).notNull(),
+	country: varchar("country", { length: 100 }).notNull(),
+	city: varchar("city", { length: 100 }).notNull(),
+	district: varchar("district", { length: 100 }).notNull(),
+	housingType: varchar("housing_type", { length: 50 }).notNull(),
+	constructionYear: integer("construction_year"),
+	wallMaterial: varchar("wall_material", { length: 50 }),
+	roofMaterial: varchar("roof_material", { length: 50 }),
+	existingProblems: text("existing_problems"),
+	email: varchar("email", { length: 255 }).notNull(),
+	phone: varchar("phone", { length: 25 }).notNull(),
+	notes: text("notes"),
+	createdAt: timestamp("created_at", { withTimezone: true })
+		.defaultNow()
+		.notNull(),
+});

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,1 +1,4 @@
-
+export * from "./schema";
+export * from "./households";
+export * from "./microfinance-institutions";
+export * from "./construction-companies";

--- a/src/db/schema/microfinance-institutions.ts
+++ b/src/db/schema/microfinance-institutions.ts
@@ -1,0 +1,20 @@
+import { timestamp, varchar, text, serial } from "drizzle-orm/pg-core";
+import { schema } from "./schema";
+
+/** MicrofinanceInstitutions stores MFI leads. */
+export const microfinanceInstitutions = schema.table(
+	"microfinance_institutions",
+	{
+		id: serial("id").primaryKey(),
+		entityName: varchar("entity_name", { length: 255 }).notNull(),
+		contactName: varchar("contact_name", { length: 255 }).notNull(),
+		email: varchar("email", { length: 255 }).notNull(),
+		phone: varchar("phone", { length: 25 }).notNull(),
+		operatingRegions: varchar("operating_regions", { length: 255 }),
+		creditTypes: text("credit_types"),
+		notes: text("notes"),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,8 +33,9 @@
 	--sidebar-accent-foreground: oklch(0.205 0 0);
 	--sidebar-border: oklch(0.922 0 0);
 	--sidebar-ring: oklch(0.708 0 0);
-	--font-sans: var(--font-sans), ui-sans-serif, system-ui, sans-serif,
-		"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	--font-sans:
+		var(--font-sans), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+		"Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 .dark {

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import {
+        households,
+        microfinanceInstitutions,
+        constructionCompanies,
+} from "@/db/schema";
+
+test("households table has essential columns", () => {
+        expect(households.fullName.name).toBe("full_name");
+        expect(households.email.notNull).toBe(true);
+});
+
+test("microfinance institutions table has essential columns", () => {
+        expect(microfinanceInstitutions.entityName.name).toBe("entity_name");
+        expect(microfinanceInstitutions.email.notNull).toBe(true);
+});
+
+test("construction companies table has essential columns", () => {
+        expect(constructionCompanies.companyName.name).toBe("company_name");
+        expect(constructionCompanies.email.notNull).toBe(true);
+});


### PR DESCRIPTION
## Summary
- define households, microfinance institutions and construction companies tables
- export new schema modules
- document DB tables in requirements
- add unit tests verifying schemas

## Testing
- `bun run format`
- `bun x tsc --noEmit` *(fails: Cannot find module 'lucide-react' etc.)*
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_687978abdfdc8320ac5a2f430813b2b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated data storage for households, microfinance institutions, and construction companies, ensuring each profile's form data is saved in separate database tables.

* **Documentation**
  * Updated requirements to specify data persistence for each user profile.

* **Style**
  * Reformatted font variable declaration in global styles for improved readability.

* **Tests**
  * Introduced unit tests to validate the structure of new database tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->